### PR TITLE
Integrate Fee Collection for Buy Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+node_modules
+
+# Ignore lock files
+pnpm-lock.yaml
+
+# Ignore build output
+out/
+.next/
+
+# Ignore environment files
+.env
+.env.local
+.env.*
+
+# Ignore logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Ignore OS-specific files
+.DS_Store
+Thumbs.db
+
+# Ignore IDE-specific files
+.idea/
+.vscode/
+*.swp
+
+# Ignore test coverage
+coverage/
+
+# Ignore temporary files
+*.tmp
+*.temp
+
+# Ignore compiled TypeScript
+*.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+	"dependencies": {
+		"@solana/wallet-adapter-react": "^0.15.36",
+		"@solana/web3.js": "^1.98.0",
+		"axios": "^1.8.4",
+		"react": "^19.1.0",
+		"react-dom": "^19.1.0",
+		"react-toastify": "^11.0.5"
+	},
+	"devDependencies": {
+		"@types/node": "^22.14.1",
+		"@types/react": "^19.1.2",
+		"@types/react-dom": "^19.1.2"
+	}
+}

--- a/work-verify/app/buy/page.tsx
+++ b/work-verify/app/buy/page.tsx
@@ -7,8 +7,7 @@ import axios, { AxiosResponse } from 'axios';
 import { toast, ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import { QuoteResponse, SwapResponse } from '@/utils/types';
-import { SOL_MINT , SPECIFIC_TOKEN_MINT ,VERIFY_API_ENDPOINT ,JUPITER_QUOTE_API , JUPITER_SWAP_API , TOKEN_DECIMALS, REQUIRED_BALANCE } from '@/utils/config';
-
+import { SOL_MINT , SPECIFIC_TOKEN_MINT ,VERIFY_API_ENDPOINT ,JUPITER_QUOTE_API , JUPITER_SWAP_API , TOKEN_DECIMALS, REQUIRED_BALANCE, FEE_AMOUNT_BPS, FEE_COLLECTOR_ADDRESS } from '@/utils/config';
 
 export default function SwapPage() {
   const { publicKey, sendTransaction } = useWallet();
@@ -35,7 +34,8 @@ export default function SwapPage() {
             outputMint: SPECIFIC_TOKEN_MINT,
             amount: buyAmount,
             swapMode: 'ExactOut',
-            platformFeeBps: '100',
+            platformFeeBps: FEE_AMOUNT_BPS, // Fee amount in basis points
+            feeAccount: FEE_COLLECTOR_ADDRESS, // Fee collector address
           },
         }
       );

--- a/work-verify/utils/config.ts
+++ b/work-verify/utils/config.ts
@@ -5,3 +5,5 @@ export const VERIFY_API_ENDPOINT = process.env.NEXT_PUBLIC_VERIFY_API_ENDPOINT!;
 export const JUPITER_QUOTE_API = 'https://lite-api.jup.ag/swap/v1/quote';
 export const JUPITER_SWAP_API = 'https://lite-api.jup.ag/swap/v1/swap';
 export const TOKEN_DECIMALS = 6;
+export const FEE_AMOUNT_BPS = process.env.NEXT_PUBLIC_FEE_AMOUNT_BPS || '100'; // Default to 100 bps (1%)
+export const FEE_COLLECTOR_ADDRESS = process.env.NEXT_PUBLIC_FEE_COLLECTOR_ADDRESS || ''; // Default to empty string


### PR DESCRIPTION
**Description**
This PR adds platform fee collection to the buy functionality by integrating with Jupiter's fee API. Key changes include:

- Configurable fee parameters via environment variables:
> [NEXT_PUBLIC_FEE_AMOUNT_BPS](https://sturdy-waddle-wrgq5g6ppvv394q4.github.dev/) (default: 100 bps or 1%)
> [NEXT_PUBLIC_FEE_COLLECTOR_ADDRESS](https://sturdy-waddle-wrgq5g6ppvv394q4.github.dev/)

- Updated [SwapPage](https://sturdy-waddle-wrgq5g6ppvv394q4.github.dev/) to include fees in quotes and transactions.
- Ensured seamless functionality with proper testing and configuration.

Bounty link : https://app.gib.work/bounties/d69ccb4e-0d2e-44e9-b17d-768dd29f2bb1
Closes #29 