### PR TITLE
fix: Discord bot channel message not sending due to missing guildId

### DIFF
--- a/work-verify/src/actions/discord.ts
+++ b/work-verify/src/actions/discord.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { DISCORD_API_URL } from "@/utils/config";
+import { DISCORD_API_URL, ANNOUNCE_CHANNEL_ID, GUILD_ID } from "@/utils/config";
 
 export const sendDiscordTipAnnounce = async ({
   receiverId,
@@ -16,7 +16,8 @@ export const sendDiscordTipAnnounce = async ({
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       message: `<@${senderId}> just sent **${amount} USDC** to <@${receiverId}>!`,
-      channelId: process.env.ANNOUNCE_CHANNEL_ID,
+      channelId: ANNOUNCE_CHANNEL_ID,
+      guildId: GUILD_ID,
     }),
   });
 };

--- a/work-verify/src/utils/config.ts
+++ b/work-verify/src/utils/config.ts
@@ -2,3 +2,5 @@ export const SOL_MINT = 'So11111111111111111111111111111111111111112';
 export const JUPITER_QUOTE_API = 'https://lite-api.jup.ag/swap/v1/quote';
 export const JUPITER_SWAP_API = 'https://lite-api.jup.ag/swap/v1/swap';
 export const DISCORD_API_URL = process.env.NEXT_PUBLIC_VERIFY_API_ENDPOINT;
+export const ANNOUNCE_CHANNEL_ID = process.env.ANNOUNCE_CHANNEL_ID;
+export const GUILD_ID = process.env.NEXT_PUBLIC_GUILD_ID;


### PR DESCRIPTION
Previously, the bot failed to send tip announcement messages in the Discord channel due to a missing required parameter.

**Problem**
When a tip was sent, the bot was expected to announce it like this:
@Worker #117 @ Gib.Work just sent 0.2 USDC to @D0t!
However, these messages were not appearing in the channel.

Upon investigation, I discovered that the Discord bot’s API endpoint required a guildId parameter, which was not being provided.

**Solution**
->Added the missing guildId parameter to the message request
->Configured necessary environment variables in the config file

Added validation to ensure the presence of ANNOUNCE_CHANNEL_ID and NEXT_PUBLIC_GUILD_ID environment variables.